### PR TITLE
Support using spundle on windows platforms

### DIFF
--- a/findAllBundlesFromRoot.js
+++ b/findAllBundlesFromRoot.js
@@ -11,11 +11,16 @@ module.exports = function gloob(dir, cb) {
     glob(path.resolve(dir, '**/*.properties'), iferr(cb, function (ents) {
         async.eachLimit(ents, 2, function(ent, next) {
             fs.readFile(ent, 'utf-8', iferr(next, function (file) {
-                out[path.relative(dir, ent)] = spud.parse(file);
+                out[getKey(dir, ent)] = spud.parse(file);
                 next();
             }));
         }, iferr(cb, function () {
             cb(null, out);
         }));
     }));
+
+    function getKey(dir, ent) {
+        var key = path.relative(dir, ent);
+        return (process.platform === 'win32') ? key.replace(/\\/g, '/') : key;
+    };
 };

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function (base, country, language, callback) {
         var out = {};
         async.eachSeries(files, function (ent, next) {
             findAllBundlesFromRoot(ent, function (err, o) {
-                out[path.relative(base, ent).replace(/(.*)\/(.*)/, "$2-$1")] = o;
+                out[path.relative(base, ent).replace(new RegExp('(.*)\\' + path.sep + '(.*)'), "$2-$1")] = o;
                 next();
             });
         }, iferr(callback, function () {

--- a/index.js
+++ b/index.js
@@ -15,12 +15,17 @@ module.exports = function (base, country, language, callback) {
         var out = {};
         async.eachSeries(files, function (ent, next) {
             findAllBundlesFromRoot(ent, function (err, o) {
-                out[path.relative(base, ent).replace(new RegExp('(.*)\\' + path.sep + '(.*)'), "$2-$1")] = o;
+                out[localeFromPath(base, ent)] = o;
                 next();
             });
         }, iferr(callback, function () {
             callback(null, out);
         }));
+
+        function localeFromPath(base, ent) {
+            var key = path.relative(base, ent);
+            return key.split(path.sep).reverse().join('-');
+        };
 
     }));
 };

--- a/test-fixtures/AR/es/nested/world.properties
+++ b/test-fixtures/AR/es/nested/world.properties
@@ -1,0 +1,1 @@
+world=a el Mundo!

--- a/test-fixtures/US/en/nested/world.properties
+++ b/test-fixtures/US/en/nested/world.properties
@@ -1,0 +1,1 @@
+world=World

--- a/test.js
+++ b/test.js
@@ -9,6 +9,8 @@ test('does it make a bundle?!', function (t) {
         t.error(err);
         t.ok(result);
         t.ok(result['en-US']);
+        t.equal(result['en-US']['world.properties'].world, 'World', 'found translation');
+        t.equal(result['en-US']['nested/world.properties'].world, 'World', 'found nested translation');
         t.notOk(result['es-AR']);
         t.end();
     });


### PR DESCRIPTION
It's a clone of https://github.com/krakenjs/spundle/pull/1 made by @bryanspears, but I'm using `path.sep` as suggested by @grawk 

All the tests are passing on Windows :+1: 
