### PR TITLE
call cb when spud.parse throws error

### DIFF
--- a/findAllBundlesFromRoot.js
+++ b/findAllBundlesFromRoot.js
@@ -10,9 +10,13 @@ module.exports = function gloob(dir, cb) {
     var out = {};
     glob(path.resolve(dir, '**/*.properties'), iferr(cb, function (ents) {
         async.eachLimit(ents, 2, function(ent, next) {
-            fs.readFile(ent, 'utf-8', iferr(cb, function (file) {
-                out[getKey(dir, ent)] = spud.parse(file);
-                next();
+            fs.readFile(ent, 'utf-8', iferr(next, function (file) {
+                try {
+                    out[getKey(dir, ent)] = spud.parse(file);
+                } catch (e) {
+                    return next(e);
+                }
+                return next();
             }));
         }, iferr(cb, function () {
             cb(null, out);

--- a/findAllBundlesFromRoot.js
+++ b/findAllBundlesFromRoot.js
@@ -10,7 +10,7 @@ module.exports = function gloob(dir, cb) {
     var out = {};
     glob(path.resolve(dir, '**/*.properties'), iferr(cb, function (ents) {
         async.eachLimit(ents, 2, function(ent, next) {
-            fs.readFile(ent, 'utf-8', iferr(next, function (file) {
+            fs.readFile(ent, 'utf-8', iferr(cb, function (file) {
                 out[getKey(dir, ent)] = spud.parse(file);
                 next();
             }));

--- a/index.js
+++ b/index.js
@@ -14,10 +14,10 @@ module.exports = function (base, country, language, callback) {
     glob(path.resolve(base, path.join(country, language)), iferr(callback, function (files) {
         var out = {};
         async.eachSeries(files, function (ent, next) {
-            findAllBundlesFromRoot(ent, function (err, o) {
+            findAllBundlesFromRoot(ent, iferr(next, function (o) {
                 out[localeFromPath(base, ent)] = o;
                 next();
-            });
+            }));
         }, iferr(callback, function () {
             callback(null, out);
         }));

--- a/test-fixtures/XX/xx/parse-error-1.properties
+++ b/test-fixtures/XX/xx/parse-error-1.properties
@@ -1,0 +1,3 @@
+# somefile.properties
+some.key=Some value
+some.key.err=Should throw error

--- a/test.js
+++ b/test.js
@@ -17,11 +17,18 @@ test('does it make a bundle?!', function (t) {
 });
 
 test('wildcards', function (t) {
-    spundle(path.resolve(__dirname, 'test-fixtures'), '*', '*', function (err, result) {
+    spundle(path.resolve(__dirname, 'test-fixtures'), '{US,AR}', '*', function (err, result) {
         t.error(err);
         t.ok(result);
         t.ok(result['en-US']);
         t.ok(result['es-AR']);
+        t.end();
+    });
+});
+
+test('parse error', function (t) {
+    spundle(path.resolve(__dirname, 'test-fixtures'), 'XX', 'xx', function (err, result) {
+        t.ok(err);
         t.end();
     });
 });


### PR DESCRIPTION
Closes #6 

Simply put, if spud throws an error, we should call the callback with the error instead of continuing the flow.

See issue #6 for more details.